### PR TITLE
fix: filter out lite versions from update checker

### DIFF
--- a/.github/workflows/bump_from_upstream.yaml
+++ b/.github/workflows/bump_from_upstream.yaml
@@ -12,7 +12,7 @@ jobs:
         run: |
           echo ::set-output name=tag::$( \
           curl https://hub.docker.com/v2/repositories/koush/scrypted/tags?count=1000 \
-          | jq -r '[.results | sort_by(.last_updated) | reverse[] | select(.name | startswith("v"))][0] | .name')
+          | jq -r '[.results | sort_by(.last_updated) | reverse[] | select(.name | startswith("v") and (endswith(".lite") | not))][0] | .name')
       - name: Check out repository code
         uses: actions/checkout@v3
       - name: 🏗 Set up yq


### PR DESCRIPTION
There are now upstream `lite` versions, which use fewer resources, but exclude some image processing tools.

The updater script is prioritizing the lite builds over the standard version. The `semver` check is saying that `v0.2.2.lite` is **not** newer than `v0.1.15`, which has resulted in updates to scrypted being broken for a while

Filtering out the `.lite` suffix seems to fix things for now (even though I'd personally prefer the `.lite` builds :) ) 